### PR TITLE
feat: add Python sub-account and omnibus margin examples

### DIFF
--- a/python/07_sub_accounts_and_gross_margin.py
+++ b/python/07_sub_accounts_and_gross_margin.py
@@ -1,0 +1,106 @@
+# Cumulus9 - All rights reserved.
+# Posting portfolios by account and sub-account, then reading gross vs. net margins.
+#
+# When `sub_account_code` is set on a position, the API stores the position
+# both at the parent (master) account level AND at the sub-account level.
+# The response contains one result row per portfolio:
+#   - The parent account row aggregates every sub-account underneath it.
+#   - Each sub-account gets its own row with `parent_portfolio_id` linking back.
+#
+# `gross_margin` is the sum of margins computed before any cross-account or
+# cross-portfolio offset; `initial_margin` is the post-offset (net) requirement.
+# Comparing the two reveals the diversification benefit at the master level.
+
+import json
+import requests
+
+# Credentials -- contact support@cumulus9.com to obtain these.
+C9_API_ENDPOINT = "xxxxxxxxxxxxxxxxxx"
+C9_API_SECRET = "sk-xxxxxxxxxxxxxxxxxx"
+
+
+HEADERS = {"Content-Type": "application/json", "Authorization": f"Bearer {C9_API_SECRET}"}
+
+
+def post_portfolio(payload: dict) -> dict:
+    response = requests.post(f"{C9_API_ENDPOINT}/portfolios", headers=HEADERS, json=payload)
+    response.raise_for_status()
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Portfolio: one master account "FUND_A" split across two sub-accounts
+# ---------------------------------------------------------------------------
+# Sub-account "STRAT_LONG" runs a long Brent Crude futures book.
+# Sub-account "STRAT_SHORT" runs a short Brent Crude futures book on the
+# same contract. At the master account level the two books partially offset,
+# so initial_margin (net) will be lower than gross_margin (sum of sub-accounts).
+
+payload = {
+    "vendor_symbology": "clearing",
+    "calculation_type": "margins",
+    "portfolio": [
+        {
+            "account_code": "FUND_A",
+            "sub_account_code": "STRAT_LONG",
+            "sub_account_name": "Long-only Energy Strategy",
+            "exchange_code": "ICE.EU",
+            "contract_code": "B",
+            "contract_type": "FUT",
+            "contract_expiry": "203612",
+            "net_position": "1000",
+            "account_type": "H",
+        },
+        {
+            "account_code": "FUND_A",
+            "sub_account_code": "STRAT_SHORT",
+            "sub_account_name": "Short-only Energy Strategy",
+            "exchange_code": "ICE.EU",
+            "contract_code": "B",
+            "contract_type": "FUT",
+            "contract_expiry": "203612",
+            "net_position": "-700",
+            "account_type": "H",
+        },
+        {
+            "account_code": "FUND_A",
+            "sub_account_code": "STRAT_LONG",
+            "exchange_code": "NYMEX",
+            "contract_code": "CL",
+            "contract_type": "FUT",
+            "contract_expiry": "203612",
+            "net_position": "500",
+            "account_type": "H",
+        },
+    ],
+}
+
+results = post_portfolio(payload)
+
+# ---------------------------------------------------------------------------
+# Inspect results
+# ---------------------------------------------------------------------------
+# `data` contains one entry per portfolio. The parent account row has no
+# `parent_portfolio_id`; sub-account rows carry their parent's portfolio_id.
+
+parents = [r for r in results["data"] if not r.get("parent_portfolio_id")]
+sub_accounts = [r for r in results["data"] if r.get("parent_portfolio_id")]
+
+print("Master accounts:")
+for r in parents:
+    im = r["initial_margin"]
+    gm = r["gross_margin"]
+    offset = gm - im
+    print(f"  {r['account_code']:<15} initial=${im:>14,.2f}  gross=${gm:>14,.2f}  offset=${offset:>12,.2f}")
+
+print("\nSub-accounts:")
+for r in sub_accounts:
+    parent = next((p for p in parents if p["portfolio_id"] == r["parent_portfolio_id"]), None)
+    parent_label = parent["account_code"] if parent else "?"
+    im = r["initial_margin"]
+    gm = r["gross_margin"]
+    print(f"  {parent_label} / {r['account_code']:<15} initial=${im:>14,.2f}  gross=${gm:>14,.2f}")
+
+# Full response for reference
+print("\nFull response:")
+print(json.dumps(results, indent=2))

--- a/python/08_omnibus_long_short.py
+++ b/python/08_omnibus_long_short.py
@@ -1,0 +1,101 @@
+# Cumulus9 - All rights reserved.
+# Using the omnibus indicator with explicit long_qty / short_qty.
+#
+# An omnibus account holds positions on behalf of multiple end-clients whose
+# longs and shorts must NOT be netted for margin purposes -- the clearing
+# house charges margin on the gross long and the gross short separately.
+#
+# To request omnibus treatment:
+#   - Set `omnibus_ind = "Y"` on the position.
+#   - Provide `long_qty` and `short_qty` instead of relying on `net_position`
+#     alone. The engine charges margin against both sides.
+#
+# Important: `omnibus_ind` applies ONLY to sub-accounts. A position must
+# carry both `account_code` (the master/clearing account) and
+# `sub_account_code` (the omnibus book) for the flag to take effect.
+# Non-omnibus sub-accounts can be submitted alongside in the same request --
+# leave `omnibus_ind` unset (or "F") for them.
+
+import json
+import requests
+
+# Credentials -- contact support@cumulus9.com to obtain these.
+C9_API_ENDPOINT = "xxxxxxxxxxxxxxxxxx"
+C9_API_SECRET = "sk-xxxxxxxxxxxxxxxxxx"
+
+HEADERS = {
+    "Content-Type": "application/json",
+    "Authorization": f"Bearer {C9_API_SECRET}",
+}
+
+
+def post_portfolio(payload: dict) -> dict:
+    response = requests.post(f"{C9_API_ENDPOINT}/portfolios", headers=HEADERS, json=payload)
+    response.raise_for_status()
+    return response.json()
+
+
+# ---------------------------------------------------------------------------
+# Portfolio: one master clearing account "FCM_001" with two sub-accounts.
+#   - OMNIBUS_A is an omnibus book: 800 long and 600 short of the same
+#     contract held for different end-clients. Margin is charged on
+#     800 long + 600 short separately (1400 contracts), NOT on the
+#     net 200 long.
+#   - PROP_DESK is a proprietary book on a different contract, with normal
+#     net-position treatment.
+# ---------------------------------------------------------------------------
+
+payload = {
+    "vendor_symbology": "clearing",
+    "calculation_type": "margins",
+    "portfolio": [
+        # Omnibus sub-account: explicit long and short legs, do not net.
+        {
+            "account_code": "FCM_001",
+            "sub_account_code": "OMNIBUS_A",
+            "sub_account_name": "Customer Omnibus Book A",
+            "exchange_code": "NYMEX",
+            "contract_code": "CL",
+            "contract_type": "FUT",
+            "contract_expiry": "203612",
+            "long_qty": "800",
+            "short_qty": "600",
+            "net_position": "200",  # = long_qty - short_qty
+            "omnibus_ind": "Y",
+            "account_type": "H",
+        },
+        # Non-omnibus prop sub-account on a different contract.
+        {
+            "account_code": "FCM_001",
+            "sub_account_code": "PROP_DESK",
+            "sub_account_name": "Proprietary Trading Desk",
+            "exchange_code": "ICE.EU",
+            "contract_code": "B",
+            "contract_type": "FUT",
+            "contract_expiry": "203612",
+            "net_position": "300",
+            "omnibus_ind": "F",
+            "account_type": "H",
+        },
+    ],
+}
+
+results = post_portfolio(payload)
+
+# ---------------------------------------------------------------------------
+# Inspect results -- compare omnibus vs. non-omnibus sub-accounts
+# ---------------------------------------------------------------------------
+
+for r in results["data"]:
+    label = r["account_code"]
+    if r.get("parent_portfolio_id"):
+        parent = next((p for p in results["data"] if p["portfolio_id"] == r["parent_portfolio_id"]), None)
+        if parent:
+            label = f"{parent['account_code']} / {r['account_code']}"
+    im = r["initial_margin"]
+    gm = r["gross_margin"]
+    print(f"{label:<30} initial_margin=${im:>14,.2f}  gross_margin=${gm:>14,.2f}")
+
+# Full response for reference
+print("\nFull response:")
+print(json.dumps(results, indent=2))


### PR DESCRIPTION
Add two Python example scripts demonstrating sub-account margin posting and omnibus long/short handling. The new examples show how to submit master and sub-account portfolios, interpret gross vs. initial margin, and use long_qty/short_qty with omnibus_ind for non-netted margin treatment.